### PR TITLE
add bounds

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -16,6 +16,10 @@ class ApiController extends Controller
             'language' => 'string',
             'referrer' => 'url|required',
             'search' => 'string|required',
+            'north' => 'numeric',
+            'south' => 'numeric',
+            'east' => 'numeric',
+            'west' => 'numeric',
         ]);
 
         if ($validator->fails()) {
@@ -50,6 +54,10 @@ class ApiController extends Controller
         })
             ->where('region', $region)
             ->where('language', $request->language)
+            ->where('north', $request->north)
+            ->where('south', $request->south)
+            ->where('east', $request->east)
+            ->where('west', $request->west)
             ->first();
 
         if ($geocode) {
@@ -60,6 +68,10 @@ class ApiController extends Controller
                     'language' => $request->language,
                     'referrer' => $request->referrer,
                     'region' => $region,
+                    'north' => $request->north ? (float) $request->north : null,
+                    'south' => $request->south ? (float) $request->south : null,
+                    'east' => $request->east ? (float) $request->east : null,
+                    'west' => $request->west ? (float) $request->west : null,
                 ],
                 ...$geocode->response,
             ];
@@ -70,6 +82,9 @@ class ApiController extends Controller
             'key' => env('GOOGLE_API_KEY'),
             'language' => $request->language,
             'region' => $region,
+            'bounds' => ($request->north && $request->south && $request->east && $request->west) ?
+                "$request->south,$request->west|$request->north,$request->east"
+                : null,
         ]))->json();
 
         if (is_array($response['results']) && count($response['results'])) {
@@ -85,6 +100,10 @@ class ApiController extends Controller
             'region' => $region,
             'response' => $response,
             'search' => $request->search,
+            'north' => $request->north,
+            'south' => $request->south,
+            'east' => $request->east,
+            'west' => $request->west,
         ]);
 
         return [
@@ -94,6 +113,10 @@ class ApiController extends Controller
                 'language' => $request->language,
                 'referrer' => $request->referrer,
                 'region' => $region,
+                'north' => $request->north,
+                'south' => $request->south,
+                'east' => $request->east,
+                'west' => $request->west,
             ],
             ...$response,
         ];

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -48,16 +48,19 @@ class ApiController extends Controller
             $domain = implode('.', $domain_parts);
         }
 
+        // allow 2 degrees (~222km) of variance in cache bounds
+        $tolerance = 2;
+
         // check database
         $geocode = Geocode::where(function ($query) use ($request) {
             return $query->where('search', $request->search)->orWhere('formatted_address', $request->search);
         })
             ->where('region', $region)
             ->where('language', $request->language)
-            ->where('north', $request->north)
-            ->where('south', $request->south)
-            ->where('east', $request->east)
-            ->where('west', $request->west)
+            ->whereBetween('north', [$request->north - $tolerance, $request->north + $tolerance])
+            ->whereBetween('south', [$request->south - $tolerance, $request->south + $tolerance])
+            ->whereBetween('east', [$request->east - $tolerance, $request->east + $tolerance])
+            ->whereBetween('west', [$request->west - $tolerance, $request->west + $tolerance])
             ->first();
 
         if ($geocode) {

--- a/app/Models/Geocode.php
+++ b/app/Models/Geocode.php
@@ -15,6 +15,10 @@ class Geocode extends Model
         'region',
         'response',
         'search',
+        'north',
+        'south',
+        'east',
+        'west',
     ];
 
     protected $casts = [

--- a/database/migrations/2025_09_04_135915_add_bounds.php
+++ b/database/migrations/2025_09_04_135915_add_bounds.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('geocodes', function (Blueprint $table) {
+            $table->decimal('north', 10, 7)->nullable()->after('language');
+            $table->decimal('south', 10, 7)->nullable()->after('north');
+            $table->decimal('east', 10, 7)->nullable()->after('south');
+            $table->decimal('west', 10, 7)->nullable()->after('east');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('geocodes', function (Blueprint $table) {
+            $table->dropColumn(['north', 'south', 'east', 'west']);
+        });
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -11,10 +11,48 @@
     .leaflet-container {
         background-color: var(--color-neutral-800) !important;
     }
+    .leaflet-control-attribution {
+        color: var(--color-neutral-400) !important;
+        background-color: var(--color-neutral-800) !important;
+        a {
+            color: var(--color-neutral-400) !important;
+        }
+    }
+    .leaflet-control-zoom {
+        background-color: var(--color-neutral-800) !important;
+        border-color: var(--color-neutral-700) !important;
+        box-shadow: none !important;
+        a {
+            background-color: var(--color-neutral-800) !important;
+            border-color: var(--color-neutral-950) !important;
+            color: var(--color-neutral-400) !important;
+            &:hover {
+                background-color: var(--color-neutral-600) !important;
+            }
+            &:active {
+                background-color: var(--color-neutral-700) !important;
+            }
+            &.leaflet-disabled {
+                background-color: var(--color-neutral-800) !important;
+                border-color: var(--color-neutral-700) !important;
+                color: var(--color-neutral-700) !important;
+                cursor: not-allowed !important;
+                box-shadow: none !important;
+            }
+        }
+    }
 }
 
 .leaflet-container:focus {
     outline: none;
+}
+
+.leaflet-control-zoom {
+    span {
+        display: flex;
+        justify-content: center;
+        line-height: 25px;
+    }
 }
 
 @theme {

--- a/resources/js/components/ui/input.tsx
+++ b/resources/js/components/ui/input.tsx
@@ -11,8 +11,8 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
         "border-input file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        "dark:bg-black"
-        
+        "dark:bg-black",
+        className,
       )}
       {...props}
     />

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -27,6 +27,7 @@ type Geocode = {
     language: string;
     referrer: string;
     search: string;
+    bounds: boolean;
 };
 
 type Domain = {
@@ -88,6 +89,7 @@ export default function Dashboard({
                             <TableRow>
                                 <TableHead>Referrer</TableHead>
                                 <TableHead>Language</TableHead>
+                                <TableHead>Bounds</TableHead>
                                 <TableHead>Search</TableHead>
                                 <TableHead>Formatted Address</TableHead>
                                 <TableHead className="text-right">Created At</TableHead>
@@ -111,6 +113,7 @@ export default function Dashboard({
                                         </a>
                                     </TableCell>
                                     <TableCell>{geocode.language}</TableCell>
+                                    <TableCell className="text-center">{geocode.bounds ? '✅' : '❌'}</TableCell>
                                     <TableCell>{geocode.search}</TableCell>
                                     <TableCell>{geocode.formatted_address}</TableCell>
                                     <TableCell className="text-right">{geocode.created_at_diff}</TableCell>

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -99,14 +99,14 @@ export default function Dashboard({
                         <TableBody>
                             {geocodes.map((geocode) => (
                                 <TableRow key={geocode.id}>
-                                    <TableCell>
+                                    <TableCell className="max-w-[350px] items-center truncate">
                                         <span
-                                            className={clsx('mr-2 rounded px-2 py-1 font-mono text-xs font-bold uppercase', {
+                                            className={clsx('mr-2 rounded px-2 py-1 font-mono text-xs font-bold text-white uppercase', {
                                                 'bg-indigo-600': geocode.application === 'tsml-ui',
                                                 'bg-neutral-600': geocode.application === 'geo',
                                             })}
                                         >
-                                            {geocode.application}
+                                            <span className="max-w-full truncate">{geocode.application}</span>
                                         </span>
                                         <a className="cursor-pointer hover:underline" href={geocode.referrer} target="_blank">
                                             {geocode.domain}
@@ -114,8 +114,8 @@ export default function Dashboard({
                                     </TableCell>
                                     <TableCell>{geocode.language}</TableCell>
                                     <TableCell className="text-center">{geocode.bounds ? '✅' : '❌'}</TableCell>
-                                    <TableCell>{geocode.search}</TableCell>
-                                    <TableCell>{geocode.formatted_address}</TableCell>
+                                    <TableCell className="whitespace-normal">{geocode.search}</TableCell>
+                                    <TableCell className="whitespace-normal">{geocode.formatted_address}</TableCell>
                                     <TableCell className="text-right">{geocode.created_at_diff}</TableCell>
                                     <TableCell className="w-2">
                                         <button onClick={() => deleteGeocode(geocode.id)} className="cursor-pointer">

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -124,7 +124,7 @@ const Location = ({
     const map = useMap();
     useEffect(() => {
         map.setView(location, 16);
-    }, [[formatted_address]]);
+    }, [formatted_address, map, location]);
     return (
         <Marker
             position={location}

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,10 +20,15 @@ Route::middleware(['auth', 'verified'])->group(function () {
             'domain',
             'referrer',
             'created_at',
-            'application'
+            'application',
+            'north',
+            'south',
+            'east',
+            'west',
         ])
             ->orderBy('created_at', 'desc')->limit(100)->get()->map(function ($geocode) {
                 $geocode->created_at_diff = Carbon::parse($geocode->created_at)->diffForHumans();
+                $geocode->bounds = $geocode->north && $geocode->south && $geocode->east && $geocode->west;
                 return $geocode;
             });
         $domains = Geocode::select('domain', DB::raw('count(*) as total'))


### PR DESCRIPTION
close #1 

the code for recovery geocoding service has been running for a few months now, but one key feature it's been missing is the ability to bias your results with the `bounds` param

<img width="1468" height="142" alt="Screenshot 2025-09-04 at 8 04 14 AM" src="https://github.com/user-attachments/assets/fc1d3cfe-c8e8-470a-ba92-ebeb9460ba24" />

this can result in bad geocodes like the one above. this person meant "lake luzerne" and not "luzerne county, pa"